### PR TITLE
Add .NET 8 support, update from template and add target of .NET Standard 2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,3 +9,5 @@ on:
 jobs:
   release:
     uses: MAFIN-Squad/workflows/.github/workflows/package-release.yml@main
+    secrets:
+      nuget-key: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,24 +6,6 @@ on:
     tags:
     - 'v*'
 
-env:
-  CONFIGURATION: Release
-  PACKAGE_OUPUT_DIRECTORY: ${{ github.workspace }}/output
-
 jobs:
   release:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 7.0.x
-
-    - name: Pack solution
-      run: dotnet pack -o ${{ env.PACKAGE_OUPUT_DIRECTORY }} -c ${{ env.CONFIGURATION }} --include-symbols
-
-    - name: Publish to NuGet
-      run: dotnet nuget push ${{ env.PACKAGE_OUPUT_DIRECTORY }}/*.nupkg -k ${{ secrets.NUGET_API_KEY }}
+    uses: MAFIN-Squad/workflows/.github/workflows/package-release.yml@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,29 +7,6 @@ on:
   push:
     branches: [ main ]
 
-env:
-  CONFIGURATION: Release
-
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 7.0.x
-
-    - name: Restore dependencies
-      run: dotnet restore
-
-    - name: Build solution
-      run: dotnet build -c ${{ env.CONFIGURATION }} --no-restore
-
-    - name: Run unit tests
-      run: dotnet test tests/*.Unit/*.csproj -c ${{ env.CONFIGURATION }} --no-build --collect:"XPlat Code Coverage"
-
-    - name: Upload code coverage results
-      uses: codecov/codecov-action@v3
+    uses: MAFIN-Squad/workflows/.github/workflows/package-test.yml@main

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,6 @@
     <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CST.DevSkim" PrivateAssets="all" />
     <PackageReference Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer" PrivateAssets="all" />
     <PackageReference Include="SonarAnalyzer.CSharp" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" PrivateAssets="all" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Features>strict</Features>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Xml" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer" Version="1.1.7" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.14.0.81108" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.15.0.81779" />
     <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507" />
     <PackageVersion Include="Tomlyn" Version="0.17.0" />
     <PackageVersion Include="xunit.analyzers" Version="1.6.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,22 +7,19 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FluentAssertions.Analyzers" Version="0.26.0" />
     <PackageVersion Include="Microsoft.CST.DevSkim" Version="1.0.23" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Xml" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Ini" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Xml" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer" Version="1.1.7" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.12.0.78982" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.14.0.81108" />
     <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507" />
-    <PackageVersion Include="Tomlyn" Version="0.16.2" />
-    <PackageVersion Include="xunit.analyzers" Version="1.4.0" />
-    <PackageVersion Include="xunit.core" Version="2.5.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageVersion Include="Tomlyn" Version="0.17.0" />
+    <PackageVersion Include="xunit.analyzers" Version="1.6.0" />
+    <PackageVersion Include="xunit.core" Version="2.6.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.4" />
     <PackageVersion Include="YamlDotNet" Version="13.7.1" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FluentAssertions.Analyzers" Version="0.26.0" />
-    <PackageVersion Include="Microsoft.CST.DevSkim" Version="1.0.23" />
+    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Ini" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="FluentAssertions.Analyzers" Version="0.26.0" />
+    <PackageVersion Include="FluentAssertions.Analyzers" Version="0.27.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
@@ -17,9 +17,9 @@
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.15.0.81779" />
     <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507" />
     <PackageVersion Include="Tomlyn" Version="0.17.0" />
-    <PackageVersion Include="xunit.analyzers" Version="1.6.0" />
-    <PackageVersion Include="xunit.core" Version="2.6.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageVersion Include="xunit.analyzers" Version="1.7.0" />
+    <PackageVersion Include="xunit.core" Version="2.6.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.5" />
     <PackageVersion Include="YamlDotNet" Version="13.7.1" />
   </ItemGroup>
 </Project>

--- a/src/Mafin.Configuration/Extensions/StringExtensions.cs
+++ b/src/Mafin.Configuration/Extensions/StringExtensions.cs
@@ -18,11 +18,34 @@ internal static class StringExtensions
             throw new ArgumentException($"'{nameof(path)}' cannot be null or whitespace.", nameof(path));
         }
 
-        if (!path.EndsWith(Path.DirectorySeparatorChar))
+        if (!path.EndsWith(Path.DirectorySeparatorChar.ToString()))
         {
             path += Path.DirectorySeparatorChar;
         }
 
         return path;
     }
+
+    /// <summary>
+    /// Checks whether <paramref name="path"/> is fully qualified.
+    /// </summary>
+    /// <param name="path"><see cref="string"/> to be checked.</param>
+    /// <returns><see langword="true"/> if the <paramref name="path"/> is fully qualified.</returns>
+    public static bool IsPathFullyQualified(this string path)
+    {
+        return Environment.OSVersion.Platform is PlatformID.Win32NT
+            ? path.Length >= 3
+                && path[1] == Path.VolumeSeparatorChar
+                && path[2] == Path.DirectorySeparatorChar
+                && IsValidDriveChar(path[0])
+            : Path.IsPathRooted(path);
+    }
+
+    /// <summary>
+    /// Checks whether <paramref name="value"/> is a valid drive letter.
+    /// </summary>
+    /// <param name="value">character to be checked.</param>
+    /// <returns><see langword="true"/> if the given character is a valid drive letter.</returns>
+    private static bool IsValidDriveChar(char value) =>
+        value is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z');
 }

--- a/src/Mafin.Configuration/Mafin.Configuration.csproj
+++ b/src/Mafin.Configuration/Mafin.Configuration.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Mafin.Configuration</PackageId>
     <Description>MAFIN Configuration package</Description>
     <Authors>MAFIN Squad</Authors>

--- a/src/Mafin.Configuration/Mafin.Configuration.csproj
+++ b/src/Mafin.Configuration/Mafin.Configuration.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Mafin.Configuration</PackageId>
     <Description>MAFIN Configuration package</Description>
     <Authors>MAFIN Squad</Authors>
@@ -13,6 +13,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="$(MSBuildProjectName).Tests.Unit" />
 
+    <PackageReference Include="Microsoft.CSharp" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" />

--- a/src/Mafin.Configuration/Mafin.Configuration.csproj
+++ b/src/Mafin.Configuration/Mafin.Configuration.csproj
@@ -13,12 +13,9 @@
   <ItemGroup>
     <InternalsVisibleTo Include="$(MSBuildProjectName).Tests.Unit" />
 
-    <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" />
     <PackageReference Include="Tomlyn" />

--- a/src/Mafin.Configuration/Mafin.Configuration.csproj
+++ b/src/Mafin.Configuration/Mafin.Configuration.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
     <PackageId>Mafin.Configuration</PackageId>
     <Description>MAFIN Configuration package</Description>
     <Authors>MAFIN Squad</Authors>

--- a/src/Mafin.Configuration/Mafin.Configuration.csproj
+++ b/src/Mafin.Configuration/Mafin.Configuration.csproj
@@ -8,7 +8,7 @@
     <RepositoryUrl>https://github.com/MAFIN-Squad/mafin-configuration</RepositoryUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.1.1</Version>
+    <Version>0.2.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="$(MSBuildProjectName).Tests.Unit" />

--- a/src/Mafin.Configuration/Models/ModuleConfig.cs
+++ b/src/Mafin.Configuration/Models/ModuleConfig.cs
@@ -16,10 +16,10 @@ internal class ModuleConfig
     /// <summary>
     /// Gets or sets value with file extensions to be loaded.
     /// </summary>
-    public List<string> FileExtensions { get; set; } = new();
+    public List<string> FileExtensions { get; set; } = [];
 
     /// <summary>
     /// Gets or sets value with list of files to be loaded.
     /// </summary>
-    public List<string> Files { get; set; } = new();
+    public List<string> Files { get; set; } = [];
 }

--- a/src/Mafin.Configuration/Parsers/TomlParser.cs
+++ b/src/Mafin.Configuration/Parsers/TomlParser.cs
@@ -10,7 +10,7 @@ namespace Mafin.Configuration.Parsers;
 /// </summary>
 internal class TomlParser
 {
-    private readonly IDictionary<string, string?> _data = new SortedDictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+    private readonly SortedDictionary<string, string?> _data = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Parses <paramref name="value"/> from TOML format.
@@ -91,7 +91,7 @@ internal class TomlParser
     private void ParseArrayNode(ArraySyntax node, Stack<string> path)
     {
         using var enumerator = node.Items.GetEnumerator();
-        int i = 0;
+        var i = 0;
         while (enumerator.MoveNext())
         {
             var value = enumerator.Current;

--- a/src/Mafin.Configuration/Parsers/YamlParser.cs
+++ b/src/Mafin.Configuration/Parsers/YamlParser.cs
@@ -10,9 +10,9 @@ namespace Mafin.Configuration.Parsers;
 /// </summary>
 internal class YamlParser
 {
-    private static readonly string[] NullValues = new[] { "null", "~" };
+    private static readonly string[] NullValues = ["null", "~"];
 
-    private readonly IDictionary<string, string?> _data = new SortedDictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+    private readonly SortedDictionary<string, string?> _data = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Parses <paramref name="unparsedStream"/> from YAML format.
@@ -28,11 +28,11 @@ internal class YamlParser
 
         _data.Clear();
 
-        using var streamReader = new StreamReader(unparsedStream);
-        var stream = new YamlStream();
+        using StreamReader streamReader = new(unparsedStream);
+        YamlStream stream = [];
         stream.Load(streamReader);
 
-        if (stream.Documents.Any())
+        if (stream.Documents.Count > 0)
         {
             var rootNode = stream.Documents.Single().RootNode;
             VisitNode(rootNode, new Stack<string>());
@@ -73,7 +73,9 @@ internal class YamlParser
             throw new FormatException();
         }
 
-        _data[formattedPath] = IsNullValue(node) ? null : node.Value;
+        _data[formattedPath] = IsNullValue(node)
+            ? null
+            : node.Value;
     }
 
     private void VisitMappingNode(YamlMappingNode node, Stack<string> path)
@@ -86,7 +88,7 @@ internal class YamlParser
 
     private void VisitSequenceNode(YamlSequenceNode node, Stack<string> path)
     {
-        for (int i = 0; i < node.Children.Count; i++)
+        for (var i = 0; i < node.Children.Count; i++)
         {
             path.Push(i.ToString(CultureInfo.CurrentCulture));
             VisitNode(node.Children[i], path);

--- a/src/Mafin.Configuration/Providers/DirectoryProbing/DirectoryProbingConfigurationBuilderExtensions.cs
+++ b/src/Mafin.Configuration/Providers/DirectoryProbing/DirectoryProbingConfigurationBuilderExtensions.cs
@@ -13,10 +13,8 @@ public static class DirectoryProbingConfigurationBuilderExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder AddDirectoryProbing(this IConfigurationBuilder builder)
-    {
-        return AddDirectoryProbing(builder, DirectoryProbingConfigurationSource.AllFilesPattern);
-    }
+    public static IConfigurationBuilder AddDirectoryProbing(this IConfigurationBuilder builder) =>
+        AddDirectoryProbing(builder, DirectoryProbingConfigurationSource.AllFilesPattern);
 
     /// <summary>
     /// Adds a directory probing configuration source to <paramref name="builder"/>.
@@ -24,12 +22,8 @@ public static class DirectoryProbingConfigurationBuilderExtensions
     /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
     /// <param name="filePathPattern">The <see cref="string"/> with pattern of the name of the file to be probed.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder AddDirectoryProbing(
-        this IConfigurationBuilder builder,
-        string filePathPattern)
-    {
-        return AddDirectoryProbing(builder, new[] { filePathPattern });
-    }
+    public static IConfigurationBuilder AddDirectoryProbing(this IConfigurationBuilder builder, string filePathPattern) =>
+        AddDirectoryProbing(builder, new[] { filePathPattern });
 
     /// <summary>
     /// Adds a directory probing configuration source to <paramref name="builder"/>.
@@ -37,12 +31,8 @@ public static class DirectoryProbingConfigurationBuilderExtensions
     /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
     /// <param name="filePathPatterns">The <see cref="IEnumerable{String}"/> with patterns of the name of the file to be probed.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder AddDirectoryProbing(
-        this IConfigurationBuilder builder,
-        IEnumerable<string> filePathPatterns)
-    {
-        return AddDirectoryProbing(builder, filePathPatterns, Environment.CurrentDirectory);
-    }
+    public static IConfigurationBuilder AddDirectoryProbing(this IConfigurationBuilder builder, IEnumerable<string> filePathPatterns) =>
+        AddDirectoryProbing(builder, filePathPatterns, Environment.CurrentDirectory);
 
     /// <summary>
     /// Adds a directory probing configuration source to <paramref name="builder"/>.
@@ -51,13 +41,8 @@ public static class DirectoryProbingConfigurationBuilderExtensions
     /// <param name="filePathPattern">The <see cref="string"/> with pattern of the name of the file to be probed.</param>
     /// <param name="baseDirectory">The <see cref="string"/> with base directory.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder AddDirectoryProbing(
-        this IConfigurationBuilder builder,
-        string filePathPattern,
-        string baseDirectory)
-    {
-        return AddDirectoryProbing(builder, new[] { filePathPattern }, baseDirectory);
-    }
+    public static IConfigurationBuilder AddDirectoryProbing(this IConfigurationBuilder builder, string filePathPattern, string baseDirectory) =>
+        AddDirectoryProbing(builder, new[] { filePathPattern }, baseDirectory);
 
     /// <summary>
     /// Adds a directory probing configuration source to <paramref name="builder"/>.
@@ -66,13 +51,8 @@ public static class DirectoryProbingConfigurationBuilderExtensions
     /// <param name="filePathPatterns">The <see cref="IEnumerable{String}"/> with patterns of the name of the file to be probed.</param>
     /// <param name="baseDirectory">The <see cref="string"/> with base directory.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder AddDirectoryProbing(
-        this IConfigurationBuilder builder,
-        IEnumerable<string> filePathPatterns,
-        string baseDirectory)
-    {
-        return AddDirectoryProbing(builder, filePathPatterns, baseDirectory, formatSourceMap: null);
-    }
+    public static IConfigurationBuilder AddDirectoryProbing(this IConfigurationBuilder builder, IEnumerable<string> filePathPatterns, string baseDirectory) =>
+        AddDirectoryProbing(builder, filePathPatterns, baseDirectory, formatSourceMap: null);
 
     /// <summary>
     /// Adds a directory probing configuration source to <paramref name="builder"/>.
@@ -95,7 +75,7 @@ public static class DirectoryProbingConfigurationBuilderExtensions
     /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
     /// <param name="filePathPatterns">The <see cref="IEnumerable{String}"/> with patterns of the name of the file to be probed.</param>
     /// <param name="baseDirectory">The <see cref="string"/> with base directory.</param>
-    /// <param name="formatSourceMap">The dictionarythat contains the relation of the file format to the function that creating the corresponding <see cref="FileConfigurationSource"/>.</param>
+    /// <param name="formatSourceMap">The dictionary that contains the relation of the file format to the function that creating the corresponding <see cref="FileConfigurationSource"/>.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
     public static IConfigurationBuilder AddDirectoryProbing(
         this IConfigurationBuilder builder,
@@ -172,6 +152,6 @@ public static class DirectoryProbingConfigurationBuilderExtensions
     /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
     /// <param name="configureSource">Action to Configure the source.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder AddDirectoryProbing(this IConfigurationBuilder builder, Action<DirectoryProbingConfigurationSource> configureSource)
-        => builder.Add(configureSource);
+    public static IConfigurationBuilder AddDirectoryProbing(this IConfigurationBuilder builder, Action<DirectoryProbingConfigurationSource> configureSource) =>
+        builder.Add(configureSource);
 }

--- a/src/Mafin.Configuration/Providers/DirectoryProbing/DirectoryProbingConfigurationProvider.cs
+++ b/src/Mafin.Configuration/Providers/DirectoryProbing/DirectoryProbingConfigurationProvider.cs
@@ -18,12 +18,7 @@ public class DirectoryProbingConfigurationProvider : IConfigurationProvider, IDi
     /// <param name="source">The source settings.</param>
     public DirectoryProbingConfigurationProvider(DirectoryProbingConfigurationSource source)
     {
-        if (source is null)
-        {
-            throw new ArgumentNullException(nameof(source), $"'{nameof(source)}' cannot be null");
-        }
-
-        _source = source;
+        _source = source ?? throw new ArgumentNullException(nameof(source), $"'{nameof(source)}' cannot be null");
     }
 
     /// <summary>
@@ -79,13 +74,12 @@ public class DirectoryProbingConfigurationProvider : IConfigurationProvider, IDi
         IEnumerable<string> earlierKeys,
         string? parentPath)
     {
-        IConfiguration section = parentPath == null ? Configuration : Configuration.GetSection(parentPath);
-        var keys = new List<string>();
-        foreach (IConfigurationSection child in section.GetChildren())
-        {
-            keys.Add(child.Key);
-        }
+        var section = parentPath == null
+            ? Configuration
+            : Configuration.GetSection(parentPath);
 
+        List<string> keys = [];
+        keys.AddRange(section.GetChildren().Select(child => child.Key));
         keys.AddRange(earlierKeys);
 
         return keys;
@@ -96,7 +90,7 @@ public class DirectoryProbingConfigurationProvider : IConfigurationProvider, IDi
     /// </summary>
     public void Load()
     {
-        var builder = new ConfigurationBuilder();
+        ConfigurationBuilder builder = new();
         foreach (var source in _source.Sources)
         {
             builder.Add(source);

--- a/src/Mafin.Configuration/Providers/DirectoryProbing/DirectoryProbingConfigurationProvider.cs
+++ b/src/Mafin.Configuration/Providers/DirectoryProbing/DirectoryProbingConfigurationProvider.cs
@@ -70,9 +70,7 @@ public class DirectoryProbingConfigurationProvider : IConfigurationProvider, IDi
     /// <param name="earlierKeys">The child keys returned by the preceding providers for the same parent path.</param>
     /// <param name="parentPath">The parent path.</param>
     /// <returns>The child keys.</returns>
-    public IEnumerable<string> GetChildKeys(
-        IEnumerable<string> earlierKeys,
-        string? parentPath)
+    public IEnumerable<string> GetChildKeys(IEnumerable<string> earlierKeys, string? parentPath)
     {
         var section = parentPath == null
             ? Configuration

--- a/src/Mafin.Configuration/Providers/DirectoryProbing/DirectoryProbingConfigurationSource.cs
+++ b/src/Mafin.Configuration/Providers/DirectoryProbing/DirectoryProbingConfigurationSource.cs
@@ -88,7 +88,7 @@ public class DirectoryProbingConfigurationSource : FileConfigurationSource
 
     private List<string> GetConfigurationFiles()
     {
-        var result = new List<string>();
+        List<string> result = [];
 
         foreach (var pattern in FilePathPatterns)
         {
@@ -107,7 +107,7 @@ public class DirectoryProbingConfigurationSource : FileConfigurationSource
 
     private List<FileConfigurationSource> CreateConfigurationSources(IEnumerable<string> files)
     {
-        var result = new List<FileConfigurationSource>();
+        List<FileConfigurationSource> result = [];
 
         foreach (var filePath in files)
         {

--- a/src/Mafin.Configuration/Providers/SettingsFile/SettingsFileConfigurationBuilderExtensions.cs
+++ b/src/Mafin.Configuration/Providers/SettingsFile/SettingsFileConfigurationBuilderExtensions.cs
@@ -17,10 +17,7 @@ public static class SettingsFileConfigurationBuilderExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder LoadSettingsFile(this IConfigurationBuilder builder)
-    {
-        return LoadSettingsFile(builder, DefaultSettingsFile);
-    }
+    public static IConfigurationBuilder LoadSettingsFile(this IConfigurationBuilder builder) => LoadSettingsFile(builder, DefaultSettingsFile);
 
     /// <summary>
     /// Adds configuration source parameters from module settings file to <paramref name="builder"/>.
@@ -29,10 +26,8 @@ public static class SettingsFileConfigurationBuilderExtensions
     /// <param name="path">Path relative to the base path stored in
     /// <see cref="IConfigurationBuilder.Properties"/> of <paramref name="builder"/>.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder LoadSettingsFile(this IConfigurationBuilder builder, string path)
-    {
-        return LoadSettingsFile(builder, provider: null, path: path, optional: false, reloadOnChange: false);
-    }
+    public static IConfigurationBuilder LoadSettingsFile(this IConfigurationBuilder builder, string path) =>
+        LoadSettingsFile(builder, provider: null, path: path, optional: false, reloadOnChange: false);
 
     /// <summary>
     /// Adds configuration source parameters from module settings file to <paramref name="builder"/>.
@@ -42,10 +37,8 @@ public static class SettingsFileConfigurationBuilderExtensions
     /// <see cref="IConfigurationBuilder.Properties"/> of <paramref name="builder"/>.</param>
     /// <param name="optional">Whether the file is optional.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder LoadSettingsFile(this IConfigurationBuilder builder, string path, bool optional)
-    {
-        return LoadSettingsFile(builder, provider: null, path: path, optional: optional, reloadOnChange: false);
-    }
+    public static IConfigurationBuilder LoadSettingsFile(this IConfigurationBuilder builder, string path, bool optional) =>
+        LoadSettingsFile(builder, provider: null, path: path, optional: optional, reloadOnChange: false);
 
     /// <summary>
     /// Adds configuration source parameters from module settings file to <paramref name="builder"/>.
@@ -56,10 +49,8 @@ public static class SettingsFileConfigurationBuilderExtensions
     /// <param name="optional">Whether the file is optional.</param>
     /// <param name="reloadOnChange">Whether the configuration should be reloaded if the file changes.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder LoadSettingsFile(this IConfigurationBuilder builder, string path, bool optional, bool reloadOnChange)
-    {
-        return LoadSettingsFile(builder, provider: null, path: path, optional: optional, reloadOnChange: reloadOnChange);
-    }
+    public static IConfigurationBuilder LoadSettingsFile(this IConfigurationBuilder builder, string path, bool optional, bool reloadOnChange) =>
+        LoadSettingsFile(builder, provider: null, path: path, optional: optional, reloadOnChange: reloadOnChange);
 
     /// <summary>
     /// Adds configuration source parameters from module settings file to <paramref name="builder"/>.
@@ -72,8 +63,8 @@ public static class SettingsFileConfigurationBuilderExtensions
     /// <param name="reloadOnChange">Whether the configuration should be reloaded if the file changes.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
     public static IConfigurationBuilder LoadSettingsFile(this IConfigurationBuilder builder, IFileProvider? provider, string path, bool optional, bool reloadOnChange)
-#pragma warning disable PH2071 // Avoid Duplicate Code
     {
+#pragma warning disable PH2071 // Avoid Duplicate Code
         if (builder == null)
         {
             throw new ArgumentNullException(nameof(builder), $"'{nameof(builder)}' cannot be null");
@@ -91,8 +82,8 @@ public static class SettingsFileConfigurationBuilderExtensions
             s.Optional = optional;
             s.ReloadOnChange = reloadOnChange;
             s.ResolveFileProvider();
-#pragma warning restore PH2071 // TODO: Refactor code to remove duplication
         });
+#pragma warning restore PH2071 // TODO: Refactor code to remove duplication
     }
 
     /// <summary>
@@ -101,6 +92,6 @@ public static class SettingsFileConfigurationBuilderExtensions
     /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
     /// <param name="configureSource">Configures the source.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder LoadSettingsFile(this IConfigurationBuilder builder, Action<SettingsFileConfigurationSource> configureSource)
-        => builder.Add(configureSource);
+    public static IConfigurationBuilder LoadSettingsFile(this IConfigurationBuilder builder, Action<SettingsFileConfigurationSource> configureSource) =>
+        builder.Add(configureSource);
 }

--- a/src/Mafin.Configuration/Providers/SettingsFile/SettingsFileConfigurationBuilderExtensions.cs
+++ b/src/Mafin.Configuration/Providers/SettingsFile/SettingsFileConfigurationBuilderExtensions.cs
@@ -63,8 +63,8 @@ public static class SettingsFileConfigurationBuilderExtensions
     /// <param name="reloadOnChange">Whether the configuration should be reloaded if the file changes.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
     public static IConfigurationBuilder LoadSettingsFile(this IConfigurationBuilder builder, IFileProvider? provider, string path, bool optional, bool reloadOnChange)
-    {
 #pragma warning disable PH2071 // Avoid Duplicate Code
+    {
         if (builder == null)
         {
             throw new ArgumentNullException(nameof(builder), $"'{nameof(builder)}' cannot be null");

--- a/src/Mafin.Configuration/Providers/SettingsFile/SettingsFileConfigurationProvider.cs
+++ b/src/Mafin.Configuration/Providers/SettingsFile/SettingsFileConfigurationProvider.cs
@@ -22,12 +22,7 @@ public class SettingsFileConfigurationProvider : IConfigurationProvider, IDispos
     /// <param name="source">The source settings.</param>
     public SettingsFileConfigurationProvider(SettingsFileConfigurationSource source)
     {
-        if (source is null)
-        {
-            throw new ArgumentNullException(nameof(source), $"'{nameof(source)}' cannot be null");
-        }
-
-        _source = source;
+        _source = source ?? throw new ArgumentNullException(nameof(source), $"'{nameof(source)}' cannot be null");
     }
 
     /// <summary>
@@ -79,17 +74,14 @@ public class SettingsFileConfigurationProvider : IConfigurationProvider, IDispos
     /// <param name="earlierKeys">The child keys returned by the preceding providers for the same parent path.</param>
     /// <param name="parentPath">The parent path.</param>
     /// <returns>The child keys.</returns>
-    public IEnumerable<string> GetChildKeys(
-        IEnumerable<string> earlierKeys,
-        string? parentPath)
+    public IEnumerable<string> GetChildKeys(IEnumerable<string> earlierKeys, string? parentPath)
     {
-        IConfiguration section = parentPath == null ? Configuration : Configuration.GetSection(parentPath);
-        var keys = new List<string>();
-        foreach (IConfigurationSection child in section.GetChildren())
-        {
-            keys.Add(child.Key);
-        }
+        IConfiguration section = parentPath == null
+            ? Configuration
+            : Configuration.GetSection(parentPath);
 
+        List<string> keys = [];
+        keys.AddRange(section.GetChildren().Select(child => child.Key));
         keys.AddRange(earlierKeys);
 
         return keys;
@@ -157,20 +149,20 @@ public class SettingsFileConfigurationProvider : IConfigurationProvider, IDispos
     private IConfiguration LoadConfig()
     {
         var basePath = _providerConfig!.Directory ?? Environment.CurrentDirectory;
-        var filter = new List<string>();
+        List<string> filter = [];
 
-        if (_providerConfig.FileExtensions?.Any() ?? false)
+        if (_providerConfig.FileExtensions?.Count > 0)
         {
             var extensions = _providerConfig.FileExtensions.Select(x => Path.ChangeExtension("*", x));
             filter.AddRange(extensions);
         }
 
-        if (_providerConfig.Files?.Any() ?? false)
+        if (_providerConfig.Files?.Count > 0)
         {
             filter.AddRange(_providerConfig.Files);
         }
 
-        if (!filter.Any())
+        if (filter.Count is 0)
         {
             filter.Add("*.*");
         }

--- a/src/Mafin.Configuration/Providers/Toml/TomlConfigurationBuilderExtensions.cs
+++ b/src/Mafin.Configuration/Providers/Toml/TomlConfigurationBuilderExtensions.cs
@@ -17,10 +17,8 @@ public static class TomlConfigurationBuilderExtensions
     /// <param name="path">Path relative to the base path stored in
     /// <see cref="IConfigurationBuilder.Properties"/> of <paramref name="builder"/>.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, string path)
-    {
-        return AddTomlFile(builder, provider: null, path: path, optional: false, reloadOnChange: false);
-    }
+    public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, string path) =>
+        AddTomlFile(builder, provider: null, path: path, optional: false, reloadOnChange: false);
 
     /// <summary>
     /// Adds a TOML configuration source to <paramref name="builder"/>.
@@ -30,10 +28,8 @@ public static class TomlConfigurationBuilderExtensions
     /// <see cref="IConfigurationBuilder.Properties"/> of <paramref name="builder"/>.</param>
     /// <param name="optional">Whether the file is optional.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, string path, bool optional)
-    {
-        return AddTomlFile(builder, provider: null, path: path, optional: optional, reloadOnChange: false);
-    }
+    public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, string path, bool optional) =>
+        AddTomlFile(builder, provider: null, path: path, optional: optional, reloadOnChange: false);
 
     /// <summary>
     /// Adds a TOML configuration source to <paramref name="builder"/>.
@@ -44,10 +40,8 @@ public static class TomlConfigurationBuilderExtensions
     /// <param name="optional">Whether the file is optional.</param>
     /// <param name="reloadOnChange">Whether the configuration should be reloaded if the file changes.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, string path, bool optional, bool reloadOnChange)
-    {
-        return AddTomlFile(builder, provider: null, path: path, optional: optional, reloadOnChange: reloadOnChange);
-    }
+    public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, string path, bool optional, bool reloadOnChange) =>
+        AddTomlFile(builder, provider: null, path: path, optional: optional, reloadOnChange: reloadOnChange);
 
     /// <summary>
     /// Adds a TOML configuration source to <paramref name="builder"/>.
@@ -61,6 +55,7 @@ public static class TomlConfigurationBuilderExtensions
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
     public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, IFileProvider? provider, string path, bool optional, bool reloadOnChange)
     {
+#pragma warning disable PH2071 // Avoid Duplicate Code
         if (builder == null)
         {
             throw new ArgumentNullException(nameof(builder), $"'{nameof(builder)}' cannot be null");
@@ -79,6 +74,7 @@ public static class TomlConfigurationBuilderExtensions
             s.ReloadOnChange = reloadOnChange;
             s.ResolveFileProvider();
         });
+#pragma warning restore PH2071 // TODO: Refactor code to remove duplication
     }
 
     /// <summary>
@@ -87,8 +83,8 @@ public static class TomlConfigurationBuilderExtensions
     /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
     /// <param name="configureSource">Configures the source.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, Action<TomlConfigurationSource> configureSource)
-        => builder.Add(configureSource);
+    public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, Action<TomlConfigurationSource> configureSource) =>
+        builder.Add(configureSource);
 
     /// <summary>
     /// Adds a TOML configuration source to <paramref name="builder"/>.
@@ -104,10 +100,9 @@ public static class TomlConfigurationBuilderExtensions
         }
 
         IDictionary<string, string?> data;
-
         try
         {
-            using var reader = new StreamReader(stream);
+            using StreamReader reader = new(stream);
             data = new TomlParser().Parse(reader.ReadToEnd());
         }
         catch (Exception e)
@@ -115,7 +110,7 @@ public static class TomlConfigurationBuilderExtensions
             throw new FormatException("Unable to parse configuration file in TOML format.", e);
         }
 
-        var source = new MemoryConfigurationSource() { InitialData = data };
+        MemoryConfigurationSource source = new() { InitialData = data };
         return builder.Add(source);
     }
 }

--- a/src/Mafin.Configuration/Providers/Toml/TomlConfigurationBuilderExtensions.cs
+++ b/src/Mafin.Configuration/Providers/Toml/TomlConfigurationBuilderExtensions.cs
@@ -54,8 +54,8 @@ public static class TomlConfigurationBuilderExtensions
     /// <param name="reloadOnChange">Whether the configuration should be reloaded if the file changes.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
     public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, IFileProvider? provider, string path, bool optional, bool reloadOnChange)
-    {
 #pragma warning disable PH2071 // Avoid Duplicate Code
+    {
         if (builder == null)
         {
             throw new ArgumentNullException(nameof(builder), $"'{nameof(builder)}' cannot be null");

--- a/src/Mafin.Configuration/Providers/Toml/TomlConfigurationProvider.cs
+++ b/src/Mafin.Configuration/Providers/Toml/TomlConfigurationProvider.cs
@@ -15,10 +15,6 @@ public class TomlConfigurationProvider : FileConfigurationProvider
     public TomlConfigurationProvider(FileConfigurationSource source)
         : base(source)
     {
-        if (source is null)
-        {
-            throw new ArgumentNullException(nameof(source), $"'{nameof(source)}' cannot be null");
-        }
     }
 
     /// <inheritdoc/>
@@ -26,8 +22,8 @@ public class TomlConfigurationProvider : FileConfigurationProvider
     {
         try
         {
-            using var reader = new StreamReader(stream);
-            var parser = new TomlParser();
+            using StreamReader reader = new(stream);
+            TomlParser parser = new();
             Data = parser.Parse(reader.ReadToEnd());
         }
         catch (Exception e)

--- a/src/Mafin.Configuration/Providers/Toml/TomlConfigurationProvider.cs
+++ b/src/Mafin.Configuration/Providers/Toml/TomlConfigurationProvider.cs
@@ -6,17 +6,12 @@ namespace Mafin.Configuration.Providers.Toml;
 /// <summary>
 /// A TOML file based <see cref="FileConfigurationProvider"/>.
 /// </summary>
-public class TomlConfigurationProvider : FileConfigurationProvider
+/// <remarks>
+/// Initializes a new instance of the <see cref="TomlConfigurationProvider"/> class.
+/// </remarks>
+/// <param name="source">The source settings.</param>
+public class TomlConfigurationProvider(FileConfigurationSource source) : FileConfigurationProvider(source)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="TomlConfigurationProvider"/> class.
-    /// </summary>
-    /// <param name="source">The source settings.</param>
-    public TomlConfigurationProvider(FileConfigurationSource source)
-        : base(source)
-    {
-    }
-
     /// <inheritdoc/>
     public override void Load(Stream stream)
     {

--- a/src/Mafin.Configuration/Providers/Yaml/YamlConfigurationBuilderExtensions.cs
+++ b/src/Mafin.Configuration/Providers/Yaml/YamlConfigurationBuilderExtensions.cs
@@ -55,8 +55,8 @@ public static class YamlConfigurationBuilderExtensions
     /// <param name="reloadOnChange">Whether the configuration should be reloaded if the file changes.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
     public static IConfigurationBuilder AddYamlFile(this IConfigurationBuilder builder, IFileProvider? provider, string path, bool optional, bool reloadOnChange)
-    {
 #pragma warning disable PH2071 // Avoid Duplicate Code
+    {
         if (builder == null)
         {
             throw new ArgumentNullException(nameof(builder), $"'{nameof(builder)}' cannot be null");

--- a/src/Mafin.Configuration/Providers/Yaml/YamlConfigurationBuilderExtensions.cs
+++ b/src/Mafin.Configuration/Providers/Yaml/YamlConfigurationBuilderExtensions.cs
@@ -18,10 +18,8 @@ public static class YamlConfigurationBuilderExtensions
     /// <param name="path">Path relative to the base path stored in
     /// <see cref="IConfigurationBuilder.Properties"/> of <paramref name="builder"/>.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder AddYamlFile(this IConfigurationBuilder builder, string path)
-    {
-        return AddYamlFile(builder, provider: null, path: path, optional: false, reloadOnChange: false);
-    }
+    public static IConfigurationBuilder AddYamlFile(this IConfigurationBuilder builder, string path) =>
+        AddYamlFile(builder, provider: null, path: path, optional: false, reloadOnChange: false);
 
     /// <summary>
     /// Adds a TOML configuration source to <paramref name="builder"/>.
@@ -31,10 +29,8 @@ public static class YamlConfigurationBuilderExtensions
     /// <see cref="IConfigurationBuilder.Properties"/> of <paramref name="builder"/>.</param>
     /// <param name="optional">Whether the file is optional.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder AddYamlFile(this IConfigurationBuilder builder, string path, bool optional)
-    {
-        return AddYamlFile(builder, provider: null, path: path, optional: optional, reloadOnChange: false);
-    }
+    public static IConfigurationBuilder AddYamlFile(this IConfigurationBuilder builder, string path, bool optional) =>
+        AddYamlFile(builder, provider: null, path: path, optional: optional, reloadOnChange: false);
 
     /// <summary>
     /// Adds a TOML configuration source to <paramref name="builder"/>.
@@ -45,10 +41,8 @@ public static class YamlConfigurationBuilderExtensions
     /// <param name="optional">Whether the file is optional.</param>
     /// <param name="reloadOnChange">Whether the configuration should be reloaded if the file changes.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder AddYamlFile(this IConfigurationBuilder builder, string path, bool optional, bool reloadOnChange)
-    {
-        return AddYamlFile(builder, provider: null, path: path, optional: optional, reloadOnChange: reloadOnChange);
-    }
+    public static IConfigurationBuilder AddYamlFile(this IConfigurationBuilder builder, string path, bool optional, bool reloadOnChange) =>
+        AddYamlFile(builder, provider: null, path: path, optional: optional, reloadOnChange: reloadOnChange);
 
     /// <summary>
     /// Adds a TOML configuration source to <paramref name="builder"/>.
@@ -62,6 +56,7 @@ public static class YamlConfigurationBuilderExtensions
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
     public static IConfigurationBuilder AddYamlFile(this IConfigurationBuilder builder, IFileProvider? provider, string path, bool optional, bool reloadOnChange)
     {
+#pragma warning disable PH2071 // Avoid Duplicate Code
         if (builder == null)
         {
             throw new ArgumentNullException(nameof(builder), $"'{nameof(builder)}' cannot be null");
@@ -80,6 +75,7 @@ public static class YamlConfigurationBuilderExtensions
             s.ReloadOnChange = reloadOnChange;
             s.ResolveFileProvider();
         });
+#pragma warning restore PH2071 // TODO: Refactor code to remove duplication
     }
 
     /// <summary>
@@ -88,8 +84,8 @@ public static class YamlConfigurationBuilderExtensions
     /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
     /// <param name="configureSource">Configures the source.</param>
     /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder AddYamlFile(this IConfigurationBuilder builder, Action<YamlConfigurationSource> configureSource)
-        => builder.Add(configureSource);
+    public static IConfigurationBuilder AddYamlFile(this IConfigurationBuilder builder, Action<YamlConfigurationSource> configureSource) =>
+        builder.Add(configureSource);
 
     /// <summary>
     /// Adds a TOML configuration source to <paramref name="builder"/>.
@@ -105,7 +101,6 @@ public static class YamlConfigurationBuilderExtensions
         }
 
         IDictionary<string, string?> data;
-
         try
         {
             data = new YamlParser().Parse(stream);
@@ -115,7 +110,7 @@ public static class YamlConfigurationBuilderExtensions
             throw new FormatException("Unable to parse configuration file in YAML format.", e);
         }
 
-        var source = new MemoryConfigurationSource() { InitialData = data };
+        MemoryConfigurationSource source = new() { InitialData = data };
         return builder.Add(source);
     }
 }

--- a/src/Mafin.Configuration/Providers/Yaml/YamlConfigurationProvider.cs
+++ b/src/Mafin.Configuration/Providers/Yaml/YamlConfigurationProvider.cs
@@ -7,17 +7,12 @@ namespace Mafin.Configuration.Providers.Yaml;
 /// <summary>
 /// A YAML file based <see cref="FileConfigurationProvider"/>.
 /// </summary>
-public class YamlConfigurationProvider : FileConfigurationProvider
+/// <remarks>
+/// Initializes a new instance of the <see cref="YamlConfigurationProvider"/> class.
+/// </remarks>
+/// <param name="source">The source settings.</param>
+public class YamlConfigurationProvider(FileConfigurationSource source) : FileConfigurationProvider(source)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="YamlConfigurationProvider"/> class.
-    /// </summary>
-    /// <param name="source">The source settings.</param>
-    public YamlConfigurationProvider(FileConfigurationSource source)
-        : base(source)
-    {
-    }
-
     /// <inheritdoc/>
     public override void Load(Stream stream)
     {

--- a/src/Mafin.Configuration/Providers/Yaml/YamlConfigurationProvider.cs
+++ b/src/Mafin.Configuration/Providers/Yaml/YamlConfigurationProvider.cs
@@ -16,10 +16,6 @@ public class YamlConfigurationProvider : FileConfigurationProvider
     public YamlConfigurationProvider(FileConfigurationSource source)
         : base(source)
     {
-        if (source is null)
-        {
-            throw new ArgumentNullException(nameof(source), $"'{nameof(source)}' cannot be null");
-        }
     }
 
     /// <inheritdoc/>
@@ -27,7 +23,7 @@ public class YamlConfigurationProvider : FileConfigurationProvider
     {
         try
         {
-            var parser = new YamlParser();
+            YamlParser parser = new();
             Data = parser.Parse(stream);
         }
         catch (YamlException e)

--- a/tests/Mafin.Configuration.Tests.Unit/Mafin.Configuration.Tests.Unit.csproj
+++ b/tests/Mafin.Configuration.Tests.Unit/Mafin.Configuration.Tests.Unit.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Target framework is set to .NET Standard 2.1 instead of .NET Standard 2.0 due to APIs used. Refactoring is required to lower the target.